### PR TITLE
[FIX] PDF preview now properly oriented.

### DIFF
--- a/app/file-upload/server/lib/FileUpload.js
+++ b/app/file-upload/server/lib/FileUpload.js
@@ -175,14 +175,14 @@ export const FileUpload = {
 			s.flatten({ background: '#FFFFFF' })
 				.jpeg()
 				.resize({
-					width: Math.min(height || 0, metadata.width || Infinity),
+					width: Math.min(width || 0, metadata.width || Infinity),
 					height: Math.min(height || 0, metadata.height || Infinity),
 					fit: sharp.fit.cover,
 				})
 				.pipe(sharp()
 					.resize({
-						height,
-						width: height,
+						height: height,
+						width: width,
 						fit: sharp.fit.contain,
 						background: '#FFFFFF',
 					})


### PR DESCRIPTION
Issue fixed: "PDF filles appear upside down #15012"
When resizing the image, the width was being set as the height, on line 178. And on line 184, there was nothing being assigned to the height.
After setting width to width, and assigning the height to height, the thumbnail for a PDF is displayed properly.
The only file that was changed is FileUpload.js (app>file-upload>server>lib)
This was made as part of the interview process for Front-End Developer.

<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #15012

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
![PDF preview after fix](https://user-images.githubusercontent.com/7467913/64946606-a0976780-d849-11e9-91e2-903523132162.png)

